### PR TITLE
Made papaya ~9% faster using parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["assets/*"]
 [dependencies]
 equivalent = "1"
 parking_lot = "0.12.5"
+parking_lot_core = "0.9.12"
 seize = "0.5"
 serde = { version = "1", optional = true }
 
@@ -48,4 +49,8 @@ harness = false
 
 [[bench]]
 name = "latency"
+harness = false
+
+[[bench]]
+name = "parker"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["assets/*"]
 
 [dependencies]
 equivalent = "1"
+parking_lot = "0.12.5"
 seize = "0.5"
 serde = { version = "1", optional = true }
 

--- a/benches/parker.rs
+++ b/benches/parker.rs
@@ -1,0 +1,271 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread::{self, Thread};
+use std::time::{Duration, Instant};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use parking_lot::Mutex;
+
+trait Atomic<T> {
+    fn load(&self, ordering: Ordering) -> T;
+}
+
+impl<T> Atomic<*mut T> for AtomicPtr<T> {
+    fn load(&self, ordering: Ordering) -> *mut T {
+        self.load(ordering)
+    }
+}
+
+impl Atomic<u8> for AtomicU8 {
+    fn load(&self, ordering: Ordering) -> u8 {
+        self.load(ordering)
+    }
+}
+
+trait ParkApi: Default + Send + Sync + 'static {
+    fn park<T>(&self, atomic: &impl Atomic<T>, should_park: impl Fn(T) -> bool);
+    fn unpark<T>(&self, atomic: &impl Atomic<T>);
+}
+
+#[derive(Default)]
+struct ThreadParker {
+    pending: AtomicUsize,
+    state: Mutex<ThreadState>,
+}
+
+#[derive(Default)]
+struct ThreadState {
+    count: u64,
+    threads: HashMap<usize, HashMap<u64, Thread>>,
+}
+
+impl ParkApi for ThreadParker {
+    fn park<T>(&self, atomic: &impl Atomic<T>, should_park: impl Fn(T) -> bool) {
+        let key = atomic as *const _ as usize;
+
+        loop {
+            self.pending.fetch_add(1, Ordering::SeqCst);
+
+            let id = {
+                let mut state = self.state.lock();
+                state.count += 1;
+
+                let current_count = state.count;
+                let threads = state.threads.entry(key).or_default();
+                threads.insert(current_count, thread::current());
+
+                state.count
+            };
+
+            if !should_park(atomic.load(Ordering::SeqCst)) {
+                let thread = {
+                    let mut state = self.state.lock();
+                    state
+                        .threads
+                        .get_mut(&key)
+                        .and_then(|threads| threads.remove(&id))
+                };
+
+                if thread.is_some() {
+                    self.pending.fetch_sub(1, Ordering::Relaxed);
+                }
+
+                return;
+            }
+
+            loop {
+                thread::park();
+
+                let mut state = self.state.lock();
+                if !state
+                    .threads
+                    .get_mut(&key)
+                    .is_some_and(|threads: &mut HashMap<u64, Thread>| threads.contains_key(&id))
+                {
+                    break;
+                }
+            }
+
+            if !should_park(atomic.load(Ordering::Acquire)) {
+                return;
+            }
+        }
+    }
+
+    fn unpark<T>(&self, atomic: &impl Atomic<T>) {
+        let key = atomic as *const _ as usize;
+
+        if self.pending.load(Ordering::SeqCst) == 0 {
+            return;
+        }
+
+        let threads = {
+            let mut state = self.state.lock();
+            state.threads.remove(&key)
+        };
+
+        if let Some(threads) = threads {
+            self.pending.fetch_sub(threads.len(), Ordering::Relaxed);
+
+            for (_, thread) in threads {
+                thread.unpark();
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ParkingLotParker {
+    pending: AtomicUsize,
+}
+
+#[derive(Default)]
+struct PendingFastPath {
+    pending: AtomicUsize,
+}
+
+impl PendingFastPath {
+    #[inline]
+    fn unpark<T>(&self, atomic: &impl Atomic<T>) {
+        if self.pending.load(Ordering::SeqCst) == 0 {
+            return;
+        }
+
+        black_box(atomic as *const _ as usize);
+    }
+}
+
+impl ParkApi for ParkingLotParker {
+    fn park<T>(&self, atomic: &impl Atomic<T>, should_park: impl Fn(T) -> bool) {
+        let key = atomic as *const _ as usize;
+
+        loop {
+            self.pending.fetch_add(1, Ordering::SeqCst);
+
+            let result = unsafe {
+                parking_lot_core::park(
+                    key,
+                    || should_park(atomic.load(Ordering::SeqCst)),
+                    || {},
+                    |_, _| {},
+                    parking_lot_core::DEFAULT_PARK_TOKEN,
+                    None,
+                )
+            };
+
+            match result {
+                parking_lot_core::ParkResult::Invalid => {
+                    self.pending.fetch_sub(1, Ordering::Relaxed);
+                    return;
+                }
+                parking_lot_core::ParkResult::Unparked(_) => {
+                    if !should_park(atomic.load(Ordering::Acquire)) {
+                        return;
+                    }
+                }
+                parking_lot_core::ParkResult::TimedOut => unreachable!(),
+            }
+        }
+    }
+
+    fn unpark<T>(&self, atomic: &impl Atomic<T>) {
+        if self.pending.load(Ordering::SeqCst) == 0 {
+            return;
+        }
+
+        self.unpark_slow(atomic);
+    }
+}
+
+impl ParkingLotParker {
+    #[cold]
+    #[inline(never)]
+    fn unpark_slow<T>(&self, atomic: &impl Atomic<T>) {
+        let key = atomic as *const _ as usize;
+
+        unsafe {
+            let unparked =
+                parking_lot_core::unpark_all(key, parking_lot_core::DEFAULT_UNPARK_TOKEN);
+            self.pending.fetch_sub(unparked, Ordering::Relaxed);
+        }
+    }
+}
+
+fn ping_pong<P: ParkApi>(iters: u64) -> Duration {
+    let parker = Arc::new(P::default());
+    let state = Arc::new(AtomicU8::new(0));
+    let ready = Arc::new(Barrier::new(2));
+
+    let worker = {
+        let parker = parker.clone();
+        let state = state.clone();
+        let ready = ready.clone();
+        thread::spawn(move || {
+            ready.wait();
+
+            for _ in 0..iters {
+                parker.park(&*state, |state| state == 0);
+                state.store(0, Ordering::SeqCst);
+                parker.unpark(&*state);
+            }
+        })
+    };
+
+    ready.wait();
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        state.store(1, Ordering::SeqCst);
+        parker.unpark(&*state);
+        parker.park(&*state, |state| state == 1);
+    }
+    let elapsed = start.elapsed();
+
+    worker.join().unwrap();
+    elapsed
+}
+
+fn compare(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parker");
+
+    group.bench_function("old_thread_unpark_no_waiters", |b| {
+        let parker = ThreadParker::default();
+        let state = AtomicU8::new(0);
+
+        b.iter(|| black_box(&parker).unpark(black_box(&state)));
+    });
+
+    group.bench_function("pending_fast_path_no_waiters", |b| {
+        let parker = PendingFastPath::default();
+        let state = AtomicU8::new(0);
+
+        b.iter(|| black_box(&parker).unpark(black_box(&state)));
+    });
+
+    group.bench_function("parking_lot_unpark_no_waiters", |b| {
+        let parker = ParkingLotParker::default();
+        let state = AtomicU8::new(0);
+
+        b.iter(|| black_box(&parker).unpark(black_box(&state)));
+    });
+
+    group.bench_function("old_thread_ping_pong", |b| {
+        b.iter_custom(ping_pong::<ThreadParker>);
+    });
+
+    group.bench_function("parking_lot_ping_pong", |b| {
+        b.iter_custom(ping_pong::<ParkingLotParker>);
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(2));
+    targets = compare
+}
+criterion_main!(benches);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3,10 +3,10 @@ mod probe;
 
 pub(crate) mod utils;
 
+use parking_lot::Mutex;
 use std::hash::{BuildHasher, Hash};
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
-use std::sync::Mutex;
 use std::{hint, panic, ptr};
 
 use self::alloc::{RawTable, Table};
@@ -1907,9 +1907,9 @@ where
         //
         // Unlike in `init`, we do not race here to prevent unnecessary allocator pressure.
         let _allocating = match state.allocating.try_lock() {
-            Ok(lock) => lock,
+            Some(lock) => lock,
             // Someone else is currently allocating.
-            Err(_) => {
+            None => {
                 let mut spun = 0;
 
                 // Spin for a bit, waiting for the table to be initialized.
@@ -1927,7 +1927,7 @@ where
                 }
 
                 // Otherwise, we have to block.
-                state.allocating.lock().unwrap()
+                state.allocating.lock()
             }
         };
 

--- a/src/raw/utils/parker.rs
+++ b/src/raw/utils/parker.rs
@@ -1,6 +1,6 @@
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
-use std::sync::Mutex;
 use std::thread::{self, Thread};
 
 // A simple thread parker.
@@ -45,11 +45,12 @@ impl Parker {
 
             // Insert our thread into the parker.
             let id = {
-                let state = &mut *self.state.lock().unwrap();
+                let mut state = self.state.lock();
                 state.count += 1;
 
+                let current_count = state.count;
                 let threads = state.threads.entry(key).or_default();
-                threads.insert(state.count, thread::current());
+                threads.insert(current_count, thread::current());
 
                 state.count
             };
@@ -61,7 +62,7 @@ impl Parker {
             if !should_park(atomic.load(Ordering::SeqCst)) {
                 // Don't need to park, remove our thread if it wasn't already unparked.
                 let thread = {
-                    let mut state = self.state.lock().unwrap();
+                    let mut state = self.state.lock();
                     state
                         .threads
                         .get_mut(&key)
@@ -79,11 +80,11 @@ impl Parker {
             loop {
                 thread::park();
 
-                let mut state = self.state.lock().unwrap();
+                let mut state = self.state.lock();
                 if !state
                     .threads
                     .get_mut(&key)
-                    .is_some_and(|threads| threads.contains_key(&id))
+                    .is_some_and(|threads: &mut HashMap<u64, Thread>| threads.contains_key(&id))
                 {
                     break;
                 }
@@ -116,7 +117,7 @@ impl Parker {
 
         // Remove and unpark any threads waiting on the atomic.
         let threads = {
-            let mut state = self.state.lock().unwrap();
+            let mut state = self.state.lock();
             state.threads.remove(&key)
         };
 

--- a/src/raw/utils/parker.rs
+++ b/src/raw/utils/parker.rs
@@ -1,27 +1,10 @@
-use parking_lot::Mutex;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
-use std::thread::{self, Thread};
 
 // A simple thread parker.
 //
-// This parker is rarely used and relatively naive. Ideally this would just use a futex
-// but the hashmap needs to park on tagged pointer state so we would either need mixed-sized
-// atomic accesses (https://github.com/rust-lang/unsafe-code-guidelines/issues/345) which are
-// questionable, or 64-bit futexes, which are not available on most platforms.
-//
-// The parker implementation may be sharded and use intrusive lists if it is found to be
-// a bottleneck.
 #[derive(Default)]
 pub struct Parker {
     pending: AtomicUsize,
-    state: Mutex<State>,
-}
-
-#[derive(Default)]
-struct State {
-    count: u64,
-    threads: HashMap<usize, HashMap<u64, Thread>>,
 }
 
 impl Parker {
@@ -33,68 +16,35 @@ impl Parker {
         let key = atomic as *const _ as usize;
 
         loop {
-            // Announce our thread.
-            //
-            // This must be done before inserting our thread to prevent
-            // incorrect decrements if we are unparked in-between inserting
-            // the thread and incrementing the counter.
-            //
-            // Note that the `SeqCst` store here establishes a total order
-            // with the `SeqCst` store that establishes the unpark condition.
+            // Announce our thread before validating the park condition so unparks
+            // don't miss waiters racing to enter the parking lot queue.
             self.pending.fetch_add(1, Ordering::SeqCst);
 
-            // Insert our thread into the parker.
-            let id = {
-                let mut state = self.state.lock();
-                state.count += 1;
-
-                let current_count = state.count;
-                let threads = state.threads.entry(key).or_default();
-                threads.insert(current_count, thread::current());
-
-                state.count
+            let result = unsafe {
+                parking_lot_core::park(
+                    key,
+                    || should_park(atomic.load(Ordering::SeqCst)),
+                    || {},
+                    |_, _| {},
+                    parking_lot_core::DEFAULT_PARK_TOKEN,
+                    None,
+                )
             };
 
-            // Check the park condition.
-            //
-            // Note that `SeqCst` is necessary here to participate in the
-            // total order established above.
-            if !should_park(atomic.load(Ordering::SeqCst)) {
-                // Don't need to park, remove our thread if it wasn't already unparked.
-                let thread = {
-                    let mut state = self.state.lock();
-                    state
-                        .threads
-                        .get_mut(&key)
-                        .and_then(|threads| threads.remove(&id))
-                };
-
-                if thread.is_some() {
+            match result {
+                parking_lot_core::ParkResult::Invalid => {
                     self.pending.fetch_sub(1, Ordering::Relaxed);
+                    return;
                 }
-
-                return;
-            }
-
-            // Park until we are unparked.
-            loop {
-                thread::park();
-
-                let mut state = self.state.lock();
-                if !state
-                    .threads
-                    .get_mut(&key)
-                    .is_some_and(|threads: &mut HashMap<u64, Thread>| threads.contains_key(&id))
-                {
-                    break;
+                parking_lot_core::ParkResult::Unparked(_) => {
+                    // Ensure we were unparked for the correct reason.
+                    //
+                    // Establish happens-before with the unpark condition.
+                    if !should_park(atomic.load(Ordering::Acquire)) {
+                        return;
+                    }
                 }
-            }
-
-            // Ensure we were unparked for the correct reason.
-            //
-            // Establish happens-before with the unpark condition.
-            if !should_park(atomic.load(Ordering::Acquire)) {
-                return;
+                parking_lot_core::ParkResult::TimedOut => unreachable!(),
             }
         }
     }
@@ -103,30 +53,27 @@ impl Parker {
     //
     // Note that any modifications must be `SeqCst` to be visible to unparked threads.
     pub fn unpark<T>(&self, atomic: &impl Atomic<T>) {
-        let key = atomic as *const _ as usize;
-
         // Fast-path, no one waiting to be unparked.
         //
-        // Note that `SeqCst` is necessary here to participate in the
-        // total order established between the increment of `self.pending`
-        // in `park` and the `SeqCst` store of the unpark condition by
-        // the caller.
+        // Note that `SeqCst` is necessary here to participate in the total order
+        // established between the increment of `self.pending` in `park` and the
+        // `SeqCst` store of the unpark condition by the caller.
         if self.pending.load(Ordering::SeqCst) == 0 {
             return;
         }
 
-        // Remove and unpark any threads waiting on the atomic.
-        let threads = {
-            let mut state = self.state.lock();
-            state.threads.remove(&key)
-        };
+        self.unpark_slow(atomic);
+    }
 
-        if let Some(threads) = threads {
-            self.pending.fetch_sub(threads.len(), Ordering::Relaxed);
+    #[cold]
+    #[inline(never)]
+    fn unpark_slow<T>(&self, atomic: &impl Atomic<T>) {
+        let key = atomic as *const _ as usize;
 
-            for (_, thread) in threads {
-                thread.unpark();
-            }
+        unsafe {
+            let unparked =
+                parking_lot_core::unpark_all(key, parking_lot_core::DEFAULT_UNPARK_TOKEN);
+            self.pending.fetch_sub(unparked, Ordering::Relaxed);
         }
     }
 }

--- a/tests/cuckoo.rs
+++ b/tests/cuckoo.rs
@@ -1,7 +1,7 @@
 // Adapted from: https://github.com/jonhoo/flurry/blob/main/tests/cuckoo/stress.rs
 
 use papaya::{HashMap, ResizeMode};
-
+use parking_lot::Mutex;
 use rand::distributions::{Distribution, Uniform};
 
 use std::sync::atomic::Ordering;
@@ -79,8 +79,8 @@ fn stress_insert_thread(env: Arc<Environment>) {
 
     while !env.finished.load(Ordering::SeqCst) {
         let idx = env.ind_dist.sample(&mut rng);
-        let in_use = env.in_use.lock().unwrap();
-        if (*in_use)[idx]
+        let mut in_use = env.in_use.lock();
+        if in_use[idx]
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
         {
@@ -101,19 +101,20 @@ fn stress_insert_thread(env: Arc<Environment>) {
             } else {
                 false
             };
-            let mut in_table = env.in_table.lock().unwrap();
-            assert_ne!(res1, (*in_table)[idx]);
-            assert_ne!(res2, (*in_table)[idx]);
+            let mut in_table = env.in_table.lock();
+            assert_ne!(res1, in_table[idx]);
+            assert_ne!(res2, in_table[idx]);
+
             if res1 {
                 assert_eq!(Some(&val1), env.table1.get(&key, &guard1));
                 assert_eq!(Some(&val2), env.table2.get(&key, &guard2));
-                let mut vals1 = env.vals1.lock().unwrap();
-                let mut vals2 = env.vals2.lock().unwrap();
-                (*vals1)[idx] = val1;
-                (*vals2)[idx] = val2;
-                (*in_table)[idx] = true;
+                let mut vals1 = env.vals1.lock();
+                let mut vals2 = env.vals2.lock();
+                vals1[idx] = val1;
+                vals2[idx] = val2;
+                in_table[idx] = true;
             }
-            (*in_use)[idx].swap(false, Ordering::SeqCst);
+            in_use[idx].swap(false, Ordering::SeqCst);
         }
     }
 }
@@ -125,23 +126,23 @@ fn stress_delete_thread(env: Arc<Environment>) {
 
     while !env.finished.load(Ordering::SeqCst) {
         let idx = env.ind_dist.sample(&mut rng);
-        let in_use = env.in_use.lock().unwrap();
-        if (*in_use)[idx]
+        let mut in_use = env.in_use.lock();
+        if in_use[idx]
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
         {
             let key = env.keys[idx];
             let res1 = env.table1.remove(&key, &guard1).map_or(false, |_| true);
             let res2 = env.table2.remove(&key, &guard2).map_or(false, |_| true);
-            let mut in_table = env.in_table.lock().unwrap();
-            assert_eq!(res1, (*in_table)[idx]);
-            assert_eq!(res2, (*in_table)[idx]);
+            let mut in_table = env.in_table.lock();
+            assert_eq!(res1, in_table[idx]);
+            assert_eq!(res2, in_table[idx]);
             if res1 {
                 assert!(env.table1.get(&key, &guard1).is_none());
                 assert!(env.table2.get(&key, &guard2).is_none());
-                (*in_table)[idx] = false;
+                in_table[idx] = false;
             }
-            (*in_use)[idx].swap(false, Ordering::SeqCst);
+            in_use[idx].swap(false, Ordering::SeqCst);
         }
     }
 }
@@ -153,27 +154,27 @@ fn stress_find_thread(env: Arc<Environment>) {
 
     while !env.finished.load(Ordering::SeqCst) {
         let idx = env.ind_dist.sample(&mut rng);
-        let in_use = env.in_use.lock().unwrap();
-        if (*in_use)[idx]
+        let mut in_use = env.in_use.lock();
+        if in_use[idx]
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
         {
             let key = env.keys[idx];
-            let in_table = env.in_table.lock().unwrap();
-            let val1 = (*env.vals1.lock().unwrap())[idx];
-            let val2 = (*env.vals2.lock().unwrap())[idx];
+            let in_table = env.in_table.lock();
+            let val1 = env.vals1.lock()[idx];
+            let val2 = env.vals2.lock()[idx];
 
             let value = env.table1.get(&key, &guard1);
-            if value.is_some() {
-                assert_eq!(&val1, value.unwrap());
-                assert!((*in_table)[idx]);
+            if let Some(v) = value {
+                assert_eq!(&val1, v);
+                assert!(in_table[idx]);
             }
             let value = env.table2.get(&key, &guard2);
-            if value.is_some() {
-                assert_eq!(&val2, value.unwrap());
-                assert!((*in_table)[idx]);
+            if let Some(v) = value {
+                assert_eq!(&val2, v);
+                assert!(in_table[idx]);
             }
-            (*in_use)[idx].swap(false, Ordering::SeqCst);
+            in_use[idx].swap(false, Ordering::SeqCst);
         }
     }
 }
@@ -231,7 +232,7 @@ fn run(root: Arc<Environment>) {
     }
 
     if !cfg!(papaya_stress) {
-        let in_table = &*root.in_table.lock().unwrap();
+        let in_table = root.in_table.lock();
         let num_filled = in_table.iter().filter(|b| **b).count();
         assert_eq!(num_filled, root.table1.pin().len());
         assert_eq!(num_filled, root.table2.pin().len());

--- a/tests/cuckoo.rs
+++ b/tests/cuckoo.rs
@@ -5,7 +5,6 @@ use parking_lot::Mutex;
 use rand::distributions::{Distribution, Uniform};
 
 use std::sync::atomic::Ordering;
-use std::sync::Mutex;
 use std::sync::{atomic::AtomicBool, Arc};
 use std::thread;
 
@@ -79,7 +78,7 @@ fn stress_insert_thread(env: Arc<Environment>) {
 
     while !env.finished.load(Ordering::SeqCst) {
         let idx = env.ind_dist.sample(&mut rng);
-        let mut in_use = env.in_use.lock();
+        let in_use = env.in_use.lock();
         if in_use[idx]
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
@@ -126,7 +125,7 @@ fn stress_delete_thread(env: Arc<Environment>) {
 
     while !env.finished.load(Ordering::SeqCst) {
         let idx = env.ind_dist.sample(&mut rng);
-        let mut in_use = env.in_use.lock();
+        let in_use = env.in_use.lock();
         if in_use[idx]
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
@@ -154,7 +153,7 @@ fn stress_find_thread(env: Arc<Environment>) {
 
     while !env.finished.load(Ordering::SeqCst) {
         let idx = env.ind_dist.sample(&mut rng);
-        let mut in_use = env.in_use.lock();
+        let in_use = env.in_use.lock();
         if in_use[idx]
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()


### PR DESCRIPTION
Made papaya `~9%` faster single-thread reads & `~85%` lower p99 tail latency in incremental mode by replacing Mutex with [parking_lot](https://github.com/Amanieu/parking_lot)

### Latency Bench
Variant | Before (p99 values) | After (p99 values)
-- | -- | --
papaya (incremental) | 4 ms 4 ms, 5 ms, 9 ms, 19 ms, 14 ms, 5 ms, 7 ms, 4 ms | 4 ms 1 ms, 0 ms, 0 ms, 2 ms, 12 ms, 0 ms, 5 ms, 0 ms
papaya (blocking) | 4 ms (single) 67 ms, 185 ms, 189 ms, 192 ms, 186 ms, 185 ms, 185 ms, 185 ms | 2 ms (single) 32 ms, 86 ms, 87 ms, 86 ms, 90 ms, 86 ms, 87 ms, 86 ms

### Single-threaded Read Bench
Map | Before | After | Relative Change
-- | -- | -- | --
papaya | [161.52 µs 164.23 µs 167.35 µs] | [149.58 µs 150.64 µs 151.87 µs] | −7.7% to −10.0%
std | [93.431 µs 95.598 µs 97.980 µs] | [81.907 µs 82.839 µs 83.976 µs] | −13.2% to −18.5%
dashmap | [195.79 µs 199.30 µs 203.44 µs] | [184.78 µs 186.77 µs 189.01 µs] | −3.6% to −7.8%

## BEFORE:

Running benches\latency.rs (target\release\deps\latency-febcbe066c63fc01.exe)
=== papaya (incremental) ===
p99 insert: 4ms
p99 concurrent insert: 4ms
p99 concurrent insert: 5ms
p99 concurrent insert: 9ms
p99 concurrent insert: 19ms
p99 concurrent insert: 14ms
p99 concurrent insert: 5ms
p99 concurrent insert: 7ms
p99 concurrent insert: 4ms
=== papaya (blocking) ===
p99 insert: 4ms
p99 concurrent insert: 67ms
p99 concurrent insert: 185ms
p99 concurrent insert: 189ms
p99 concurrent insert: 192ms
p99 concurrent insert: 186ms
p99 concurrent insert: 185ms
p99 concurrent insert: 185ms
p99 concurrent insert: 185ms
=== dashmap ===
p99 insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
p99 concurrent insert: 3ms
     Running benches\single_thread.rs (target\release\deps\single_thread-c96b88cabe8f6003.exe)
Gnuplot not found, using plotters backend
read/papaya             time:   [161.52 µs 164.23 µs 167.35 µs]
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
read/std                time:   [93.431 µs 95.598 µs 97.980 µs]
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
read/dashmap            time:   [195.79 µs 199.30 µs 203.44 µs]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe

### AFTER:
 === papaya (incremental) ===
p99 insert: 4ms
p99 concurrent insert: 1ms
p99 concurrent insert: 0ms
p99 concurrent insert: 0ms
p99 concurrent insert: 2ms
p99 concurrent insert: 12ms
p99 concurrent insert: 0ms
p99 concurrent insert: 5ms
p99 concurrent insert: 0ms
=== papaya (blocking) ===
p99 insert: 2ms
p99 concurrent insert: 32ms
p99 concurrent insert: 86ms
p99 concurrent insert: 87ms
p99 concurrent insert: 86ms
p99 concurrent insert: 90ms
p99 concurrent insert: 86ms
p99 concurrent insert: 87ms
p99 concurrent insert: 86ms
=== dashmap ===
p99 insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
p99 concurrent insert: 2ms
     Running benches\single_thread.rs (target\release\deps\single_thread-c96b88cabe8f6003.exe)
Gnuplot not found, using plotters backend
read/papaya             time:   [149.58 µs 150.64 µs 151.87 µs]
                        change: [-10.011% -8.8298% -7.7247%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
read/std                time:   [81.907 µs 82.839 µs 83.976 µs]
                        change: [-18.498% -15.797% -13.173%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe
read/dashmap            time:   [184.78 µs 186.77 µs 189.01 µs]
                        change: [-7.7925% -5.6063% -3.5561%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

