### PR TITLE
Avoid clobbering tombstone metadata on insert

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -902,8 +902,14 @@ where
         ) {
             // Successfully claimed the entry.
             Ok(_) => {
-                // Update the metadata table.
-                meta_entry.store(meta, Ordering::Release);
+                // Publish the metadata unless another thread already observed
+                // the entry and repaired or removed the slot.
+                let _ = meta_entry.compare_exchange(
+                    meta::EMPTY,
+                    meta,
+                    Ordering::Release,
+                    Ordering::Relaxed,
+                );
 
                 // Return the value we inserted.
                 return InsertStatus::Inserted;
@@ -2404,8 +2410,14 @@ where
                     ) {
                         // Successfully inserted.
                         Ok(_) => {
-                            // Update the metadata table.
-                            meta_entry.store(h2, Ordering::Release);
+                            // Publish the metadata unless another thread already observed
+                            // the entry and repaired or removed the slot.
+                            let _ = meta_entry.compare_exchange(
+                                meta::EMPTY,
+                                h2,
+                                Ordering::Release,
+                                Ordering::Relaxed,
+                            );
                             return Some((table, probe.i));
                         }
                         Err(found) => {


### PR DESCRIPTION
Thanks for your work on papaya! 

We found a race where `insert_at` wins the CAS for an entry and blindly stores the slot metadata, even after a concurrent remover had tombstoned the slot. This leaves `entry == NULL` but `meta == h2(k)`, so the slot isn't reusable until resize. (Can share the original repro if it's useful.)

This PR changes this to use `compare_exchange` and also updates `insert_copy` for consistency.