### PR TITLE
Skip raw::alloc::layout on 32-bit targets

### DIFF
--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -219,6 +219,8 @@ impl<T> Table<T> {
     }
 }
 
+// Expected sizes are based on 64-bit assumptions
+#[cfg(target_pointer_width = "64")]
 #[test]
 fn layout() {
     unsafe {


### PR DESCRIPTION
Expected sizes are based on 64-bit assumptions, so this avoids the following failure on 32-bit targets like i686:

```
running 1 test
test raw::alloc::layout ... FAILED

failures:

---- raw::alloc::layout stdout ----

thread 'raw::alloc::layout' (528) panicked at src/raw/alloc.rs:229:9:
assertion `left == right` failed
  left: 3
 right: 7
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    raw::alloc::layout

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```